### PR TITLE
Add node and npm version requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,9 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cazala/coin-hive.git"
+  },
+  "engines": {
+    "node": ">=8.0",
+    "npm": ">=5.0"
   }
 }


### PR DESCRIPTION
So that installation can fail fast if you have the improper versions
This was made to mitigate https://github.com/cazala/coin-hive/issues/12