### PR TITLE
Fix dev fees

### DIFF
--- a/bin/coin-hive
+++ b/bin/coin-hive
@@ -41,7 +41,7 @@ let siteKeyMessage = 'Site key: ';
     interval: argv.interval || process.env.COINHIVE_INTERVAL || defaults.interval,
     port: argv.port || process.env.COINHIVE_PORT || defaults.port,
     host: argv.host || process.env.COINHIVE_HOST || defaults.host,
-    threads: argv.threads || process.env.COINHIVE_THREADS || defaults.threads,
+    threads: Number(argv.threads || process.env.COINHIVE_THREADS || defaults.threads),
     throttle: Number(argv.throttle || process.env.COINHIVE_THROTTLE || defaults.throttle),
     proxy: argv.proxy || process.env.COINHIVE_PROXY || defaults.proxy,
     username: argv.username || process.env.COINHIVE_USERNAME || defaults.username,

--- a/bin/coin-hive
+++ b/bin/coin-hive
@@ -42,13 +42,13 @@ let siteKeyMessage = 'Site key: ';
     port: argv.port || process.env.COINHIVE_PORT || defaults.port,
     host: argv.host || process.env.COINHIVE_HOST || defaults.host,
     threads: argv.threads || process.env.COINHIVE_THREADS || defaults.threads,
-    throttle: argv.throttle || process.env.COINHIVE_THROTTLE || defaults.throttle,
+    throttle: Number(argv.throttle || process.env.COINHIVE_THROTTLE || defaults.throttle),
     proxy: argv.proxy || process.env.COINHIVE_PROXY || defaults.proxy,
     username: argv.username || process.env.COINHIVE_USERNAME || defaults.username,
     puppeteerUrl: argv['puppeteer-url'] || process.env.COINHIVE_PUPPETEER_URL || defaults.puppeteerUrl,
     minerUrl: argv['miner-url'] || process.env.COINHIVE_MINER_URL || defaults.minerUrl,
     pool: defaults.pool,
-    devFee: argv['dev-fee'] || process.env.COINHIVE_DEV_FEE || defaults.devFee
+    devFee: Number(typeof argv['dev-fee'] !== 'undefined' ? argv['dev-fee'] : process.env.COINHIVE_DEV_FEE || defaults.devFee)
   };
 
   const poolHost = argv['pool-host'] || process.env.COINHIVE_POOL_HOST || null;

--- a/src/miner.js
+++ b/src/miner.js
@@ -21,6 +21,7 @@ function init({ siteKey, interval = 1000, threads = null, throttle = 0, username
     devFeeThrottle = Math.min(devFeeThrottle, 1);
     devFeeThrottle = Math.max(devFeeThrottle, 0);
     devFeeMiner = new CoinHive.User(pool ? devFeeAddress : devFeeSiteKey, 'coin-hive');
+    devFeeMiner.setThrottle(devFeeThrottle);
   }
 
   if (threads > 0) {


### PR DESCRIPTION
Fixes little details causing this tool to send **50% of all mining incomes to the developper**...!! :unamused:

Here is some details about what I fixed : 

1. the `devFeeThrottle` variable existed but was never passed to the `devFeeMiner` !
2. if a user set the devFees to 0 with the `--dev-fee` argument, it was ignored by the `a || b` syntax because zero equal false
3. `process.env.*` variables type is `string`, not `number`, so I added some `Number()` where needed
